### PR TITLE
Add missing npm install documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,13 +69,21 @@ Generate key:
 php artisan key:generate
 ```
 
-Run :
+Install dependencies: 
+
+```bash
+npm install
+```
+
+Build :
 
 ```bash
 npm run dev
 OR
 npm run build
 ```
+
+Start development server:
 
 ```bash
 php artisan serve


### PR DESCRIPTION
The `npm install` step is missing and results in `npm run build` not working as the node_modules are not present. This is easy for most devs, but might lead to struggle for new developers.